### PR TITLE
Added supports for mirroring function parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Returns cloned object's name
 
 ```javascript
 var Glass = function (color) {
-    this.color = color
+    this.color = color;
 };
 
 Glass.prototype = (function () {
@@ -187,6 +187,16 @@ Glass.prototype = (function () {
 });
 
 console.log(mirror(Glass).name()); // Glass
+```
+
+### .parameters()
+
+Return the parameters names of the given function.
+
+```javascript
+var awesomeFunction = function (foo, bar, baz) {};
+
+console.log(mirror(awesomeFunction).parameters()); // ['foo', 'bar', 'baz']
 ```
 
 ## License

--- a/src/mirror.js
+++ b/src/mirror.js
@@ -6,8 +6,8 @@
         var mirror = (function () {
 
             function Reflect(obj) {
-                if (typeof obj !== 'object') {
-                    throw new Error('This is not an object');
+                if (typeof obj !== 'object' && typeof obj !== 'function') {
+                    throw new Error('This is not an object or function.');
                 }
 
                 this._obj = obj;
@@ -22,6 +22,10 @@
                  * @return {array}          List of properties
                  */
                 var _getProperties = function (obj, filter) {
+                    if (typeof obj !== 'object') {
+                        throw new Error('This is not an object.');
+                    }
+
                     var objProperties = [],
                         prop,
                         propFilter = filter ? new RegExp(filter, 'i') : undefined;
@@ -121,6 +125,22 @@
                      */
                     name: function () {
                         return this.construct().name;
+                    },
+
+                    /**
+                     * Returns the parameters of a function (or the parameters of the "construtor" or a "class")
+                     * @return {Array} Function parameters names
+                     */
+                    parameters: function () {
+                        var functionString = this._obj.toString(),
+                            stripCommentsReg = /(\/\/.*$)|(\/\*[\s\S]*?\*\/)|(\s*=[^,\)]*(('(?:\\'|[^'\r\n])*')|("(?:\\"|[^"\r\n])*"))|(\s*=[^,\)]*))/mg,
+                            argumentNamesReg = /([^\s,]+)/g,
+                            result = null;
+
+                        functionString = functionString.replace(stripCommentsReg, '');
+                        result = functionString.slice(functionString.indexOf('(')+1, functionString.indexOf(')')).match(argumentNamesReg);
+                        
+                        return result || [];
                     }
 
                 };

--- a/tests/mirror.js
+++ b/tests/mirror.js
@@ -16,7 +16,11 @@
                     return 'Hi People !';
                 }
             }
-        };
+        },
+
+        testFunction = function (foo, bar, baz) {};
+
+    function testSecondFunction (foo, bar, baz) {}
 
     describe('mirror()', function () {
 
@@ -214,6 +218,23 @@
             });
 
         });
+
+        describe('.parameters', function () {
+
+            it('should return an array of strings for a function', function () {
+
+                assert.typeOf(mirror(testFunction).parameters(), 'array');
+                assert.typeOf(mirror(testSecondFunction).parameters(), 'array');
+
+            });
+
+            it('should return "foo" as first parameter for the functions testFunction and testSecondFunction', function () {
+
+                assert.ok(mirror(testFunction).parameters()[0] === 'foo');
+                assert.ok(mirror(testSecondFunction).parameters()[0] === 'foo');
+                
+            });
+        })
 
     });
 


### PR DESCRIPTION
Hi,

This patch comes with a little BC Break with exceptions (it would be ugly to check for object on each function, and imo, not necessary).

But it adds a support for functions parameter. This support is ES6-compatible. The tests are green.

Hope you'll like it.
